### PR TITLE
Package Version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS",
-  "version": "0.0.0-development",
+  "version": "5.19.0",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     "Sascha Depold <sascha@depold.com>",


### PR DESCRIPTION
This PR sets the package.json version to the last tagged release in this repo. Currently ECR container scans are reporting every vulnerability ever listed for sequelize because it can't detect the correct version, this will resolve the issue. 